### PR TITLE
docs: WATCH_LATER_ALREADY_EXISTS エラーコードを削除

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -86,7 +86,6 @@
 | エラーコード | HTTP | 発生条件 |
 |---|---|---|
 | `CONTENT_NOT_FOUND` | 404 | 指定IDのコンテンツが存在しない |
-| `WATCH_LATER_ALREADY_EXISTS` | 409 | 既に「後で見る」登録済み |
 
 ### 2.6 手動ポーリング（`/api/categories/{id}/poll`）
 


### PR DESCRIPTION
Closes #2

## 対応内容

`PUT /watch-later/{contentId}` は UPSERT 設計（ON CONFLICT UPDATE）であり、既に登録済みのコンテンツを追加しようとしても常に上書きされるため、409 が発生するケースが存在しない。

`WATCH_LATER_ALREADY_EXISTS`（409）は不要なエラーコードのため、`docs/error-handling.md` から削除した。

## 対応方針（確認済み）

- UPSERT 設計を維持する
- `docs/openapi.yaml` は変更なし（PUT は 200/401/404 のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)