### PR TITLE
fix: Content スキーマの required に contentAt を追加 #4

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -171,7 +171,7 @@ components:
         updatedAt:
           type: string
           format: date-time
-      required: [id, channelId, platform, platformContentId, title, type, status, url, createdAt, updatedAt]
+      required: [id, channelId, platform, platformContentId, title, type, status, contentAt, url, createdAt, updatedAt]
 
     # --- WatchLater ---
     WatchLater:


### PR DESCRIPTION
## 概要

- `docs/openapi.yaml` の Content スキーマ `required` 配列に `contentAt` を追加

## 背景

Issue #4 の通り、`contentAt` は以下の理由から必須フィールドであるにもかかわらず `required` に未記載だった：
- `database.md`: `contentAt DateTime`（NOT NULL）
- `architecture.md` §9: カーソルページネーションのソートキーとして必須

## 変更内容

`docs/openapi.yaml` L174:
```
- required: [id, channelId, platform, platformContentId, title, type, status, url, createdAt, updatedAt]
+ required: [id, channelId, platform, platformContentId, title, type, status, contentAt, url, createdAt, updatedAt]
```

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)