### PR TITLE
docs: NextAuth のセッション方式を JWT に決定 #9

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,7 @@ type Platform = 'youtube' | 'twitch' // 将来追加
 1. ユーザーが「Googleでログイン」ボタンをクリック
 2. NextAuth → Google OAuth 2.0 認証
 3. コールバック：アクセストークン・リフレッシュトークンをDBに保存
-4. セッション確立（JWT or DB Session）
+4. セッション確立（JWT）
 5. 以降のAPI呼び出しはセッションで認証
 6. アクセストークン期限切れ時はリフレッシュトークンで自動更新
 ```


### PR DESCRIPTION
## Summary
- NextAuth のセッション方式を JWT に決定し、`docs/architecture.md` §5 を更新
- シングルユーザーアプリのため、DB アクセス不要で高速な JWT 方式が適切

## 対応方針
- JWT 方式を採用（DB Session は不採用）
- 理由: シングルユーザーのためセッション無効化の即時性は不要、DB アクセス不要で検証が高速

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)