### PR TITLE
docs: Docker Compose 詳細設定を architecture.md §7 に追記 #15

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -555,11 +555,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: mysubchs
-      POSTGRES_PASSWORD: mysubchs
-      POSTGRES_DB: mysubchs
+      POSTGRES_USER: ${POSTGRES_USER:-mysubchs}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mysubchs}
+      POSTGRES_DB: ${POSTGRES_DB:-mysubchs}
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U mysubchs']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-mysubchs}']
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

- `docs/architecture.md` §7 の Docker Compose 構成をサービス名のみの記述から詳細設定に書き換え
- 開発環境向け設定のみを対象

## 変更内容

- ポートマッピング（app:3000, db:5432, redis:6379）
- ボリューム設定（postgres_data / redis_data 名前付きボリューム、ソースバインドマウント + 匿名ボリューム）
- bridge ネットワーク `mysubchs` でサービス間通信
- ヘルスチェック（db: `pg_isready`、redis: `redis-cli ping`）
- `app` / `worker` の `depends_on` + `condition: service_healthy`
- worker エントリーポイント（`npx tsx src/jobs/worker.ts`）
- `env_file: .env` を全サービスに設定
- app ホットリロード（`npm run dev` + ソースバインドマウント）
- 補足説明を追記

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)