### PR TITLE
docs: BullMQ Repeatable Job のポーリング間隔変更メカニズムを定義

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,14 +219,16 @@ BullMQ の Repeatable Job は間隔を直接変更できないため、旧ジョ
 
 **実行コンポーネント**: Next.js API ルートハンドラ（設定変更 API `PATCH /api/settings`）
 
-設定変更 API がポーリング間隔の変更を検知した場合、DB への保存と同一トランザクション内（またはその直後）に以下のジョブ再登録処理を実行する。
+設定変更 API がポーリング間隔の変更を検知した場合、DB への保存後に以下のジョブ再登録処理を実行する。
+
+> **注**: PostgreSQL トランザクションと Redis 操作は同一トランザクションにできない。DB 保存成功 → Redis 操作失敗 の場合、DB と Redis で間隔が不整合になる可能性があるが、Worker 起動時の初期登録処理（後述）で自己修復される。
 
 **ジョブ更新手順:**
 
 ```
 1. queue.removeRepeatable("polling-job", { every: <旧間隔ms> })
    ↓
-2. queue.add("polling-job", {}, { repeat: { every: <新間隔ms> }, jobId: "polling-job" })
+2. queue.add("polling-job", {}, { repeat: { every: <新間隔ms> } })
 ```
 
 **実行中ジョブへの影響:**
@@ -235,9 +237,21 @@ BullMQ の Repeatable Job は間隔を直接変更できないため、旧ジョ
 - 新しい間隔は次のジョブサイクル開始時から適用される
 - `removeRepeatable()` は次回スケジュールのエントリのみ削除し、実行中のジョブには影響しない
 
-**Worker 起動時の初期登録との関係:**
+**Worker 起動時の初期登録:**
 
-Worker は起動時にも Repeatable Job を登録する。DB の `UserSetting.pollingIntervalMinutes` を読み取り、常に最新の間隔で登録する（既存の Repeatable Job が残っている場合は同一 `jobId` により上書きされる）。
+BullMQ の Repeatable Job は **ジョブ名 + `every` の値** を組み合わせた Redis キーで一意性が管理される。そのため、異なる `every` 値でジョブを追加しても旧エントリは自動削除されない。Worker 起動時は必ず以下の手順で登録する:
+
+```
+1. queue.getRepeatableJobs() で既存の Repeatable Job 一覧を取得
+   ↓
+2. DB の pollingIntervalMinutes を読み取り、正しい間隔（ms）を確認
+   ↓
+3. 間隔が一致しないエントリがあれば removeRepeatable() で削除
+   ↓
+4. 正しい間隔で queue.add() を実行（既に同一間隔のエントリが存在する場合はスキップ可）
+```
+
+この手順により、API ハンドラでの Redis 操作が失敗した場合も Worker 再起動時に自己修復される。
 
 ### ジョブの流れ
 


### PR DESCRIPTION
## 対応Issue

Closes #12

## 対応内容

`docs/architecture.md` §6 に「ポーリング間隔変更時の BullMQ ジョブ更新フロー」セクションを追記した。

### 追記した内容

- **ジョブ更新手順**: `queue.removeRepeatable()` で旧ジョブを削除し、新しい間隔で `queue.add()` し直す手順を明記
- **実行コンポーネント**: 設定変更 API ハンドラ（`PATCH /api/settings`）が DB 保存と同タイミングでジョブ再登録を行うと明確化
- **実行中ジョブの扱い**: 変更時点で実行中のジョブは最後まで完了させ、新しい間隔は次のサイクルから適用されると定義
- **Worker 起動時との関係**: Worker 起動時も DB から最新間隔を読み取って Repeatable Job を登録することを記述

## 確認した対応方針

- 実行コンポーネント: 設定変更 API ハンドラ（Next.js APIルート）
- 実行中ジョブ: 強制中断せず最後まで完了させる
- 変更反映タイミング: 次のジョブサイクル開始時から

🤖 Generated with [Claude Code](https://claude.com/claude-code)