### PR TITLE
docs: Content.status のデフォルト値を削除し必須フィールドに変更

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -253,7 +253,7 @@ model Content {
   platformContentId String
   title             String
   type              ContentType
-  status            ContentStatus @default(ARCHIVED)  // 動画はARCHIVED、ライブ予定はUPCOMINGで登録（デフォルトはフォールバック用）
+  status            ContentStatus                     // 動画はARCHIVED、ライブ予定はUPCOMING、配信中はLIVEで登録（常に明示指定。architecture.md §6 参照）
   publishedAt       DateTime?
   scheduledStartAt  DateTime?
   actualStartAt     DateTime?


### PR DESCRIPTION
## 対応Issue

Closes #18

## 概要

`Content.status` の `@default(ARCHIVED)` を削除し、必須フィールドに変更した。

## 対応方針

ポーリングフローでは全INSERTケースで `status` を明示的に指定しており（architecture.md §6）、デフォルト値が使われる正当なケースが存在しない。デフォルト値を維持するとコード実装時に指定を忘れた場合にDBエラーが発生せずサイレントに `ARCHIVED` として登録されるリスクがあるため、デフォルト値を削除して必須フィールドとする。

## 変更内容

- `docs/database.md`: Prismaスキーマの `status ContentStatus @default(ARCHIVED)` から `@default(ARCHIVED)` を削除し、コメントを更新