### PR TITLE
docs: Category.name に minLength/maxLength 制約を追加 #45

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -383,6 +383,8 @@ paths:
               properties:
                 name:
                   type: string
+                  minLength: 1
+                  maxLength: 50
                   example: ゲーム実況
               required: [name]
       responses:
@@ -446,6 +448,8 @@ paths:
               properties:
                 name:
                   type: string
+                  minLength: 1
+                  maxLength: 50
               required: [name]
       responses:
         '200':


### PR DESCRIPTION
## 対応Issue

Closes #45

## 対応内容

`docs/openapi.yaml` の `createCategory` および `updateCategory` リクエストスキーマの `name` フィールドに以下の制約を追加しました。

- `minLength: 1`（空文字不可）
- `maxLength: 50`（最大50文字）

`requirements.md §2.2` で定義済みだったバリデーションルールが openapi.yaml に反映されていなかった不足を修正します。

## 変更ファイル

- `docs/openapi.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)