### PR TITLE
docs: 手動ポーリングクールダウンのレスポンス形式の記述を openapi.yaml に一本化 #44

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -515,7 +515,7 @@ POST /api/categories/{categoryId}/poll
 
 - 同一カテゴリへの手動ポーリングは最低**5分間のクールダウン**を設ける
 - 実装：Redis に `manual-poll:cooldown:{categoryId}` キーを TTL=300秒 でセット
-- クールダウン中のリクエストは `{ queued: false, reason: "cooldown", retryAfter: <残り秒数> }` を返す（HTTP 429）
+- クールダウン中のリクエストは HTTP 429 を返す（レスポンスボディは openapi.yaml の `Error` スキーマ参照）
 - UIはこのレスポンスを受けてボタンを非活性化し残り時間を表示する
 
 **ジョブステータス確認 API:**

--- a/docs/ui/dashboard.md
+++ b/docs/ui/dashboard.md
@@ -121,7 +121,7 @@
 
 - クリック後、`POST /api/categories/{categoryId}/poll` を呼び出す
 - ポーリングはバックグラウンドで非同期実行される（APIはジョブのキューへの追加成功のみ応答する）
-- APIから `429 Too Many Requests` が返った場合（クールダウン中）：ボタンをクールダウン状態にし、`retryAfter` 秒のカウントダウンを表示する
+- APIから `429 Too Many Requests` が返った場合（クールダウン中）：ボタンをクールダウン状態にし、レスポンスの `error.retryAfter` 秒のカウントダウンを表示する
 
 **POST 後のジョブ完了検知:**
 


### PR DESCRIPTION
## 対応内容

Closes #44

`architecture.md` と `openapi.yaml` でクールダウン時レスポンスのスキーマ定義が二重管理されていた問題を解消する。

## 対応方針

openapi.yaml を API レスポンスの唯一の正規定義とし、architecture.md からスキーマ詳細を削除して参照に置き換える。

## 変更内容

- `docs/architecture.md`: クールダウン中のレスポンスボディの JSON 記述を削除し、`openapi.yaml の Error スキーマ参照` に置き換え
- `docs/ui/dashboard.md`: クライアント側のフィールド参照を `retryAfter` → `error.retryAfter` に更新