### PR TITLE
spec: VAPID 公開鍵のフロントエンドへの受け渡し方法を定義 #53

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -117,6 +117,7 @@ REDIS_URL=
 # Web Push
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=  # VAPID_PUBLIC_KEY と同じ値を設定する。Next.js の NEXT_PUBLIC_ プレフィックスによりブラウザ（フロントエンド）から参照可能になる。秘密情報ではないため公開して問題ない。
 ```
 
 ---

--- a/docs/ui/settings.md
+++ b/docs/ui/settings.md
@@ -363,7 +363,7 @@
 2. 許可された場合：
    a. navigator.serviceWorker.ready でService Workerの準備を待つ
    b. pushManager.subscribe() で PushSubscription を取得する
-      （applicationServerKey には VAPID 公開鍵を使用）
+      - applicationServerKey: 環境変数 `NEXT_PUBLIC_VAPID_PUBLIC_KEY` の値をそのまま渡す（Base64url 文字列。対象ブラウザはすべて文字列形式を直接受け付ける）
    c. POST /api/notifications/subscriptions で登録する
    d. 成功：状態を「有効化済み」に切り替える
 3. 拒否された場合：


### PR DESCRIPTION
## 対応内容

Closes #53

- `docs/infrastructure.md`: 環境変数セクションに `NEXT_PUBLIC_VAPID_PUBLIC_KEY` を追加。`VAPID_PUBLIC_KEY` と同じ値を設定し、`NEXT_PUBLIC_` プレフィックスによりブラウザから参照可能にする
- `docs/ui/settings.md` §9.3: `pushManager.subscribe()` の `applicationServerKey` に `NEXT_PUBLIC_VAPID_PUBLIC_KEY` をそのまま（Base64url 文字列として）渡す旨を明記。対象ブラウザ（Chrome/Firefox/Safari/Edge 最新版）はすべて文字列形式を直接受け付けるため変換不要

## 設計判断

- `Uint8Array` への変換は不要。`docs/requirements.md` §3.1 でモダンブラウザ（Chrome/Firefox/Safari/Edge 最新版）が対象と定義されており、いずれも `applicationServerKey` に Base64url 文字列を直接渡すことができる