### PR TITLE
fix: LIVE コンテンツの ContentCleanup 削除基準日時を actualStartAt 優先に変更 #57

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -510,7 +510,7 @@ stateDiagram-v2
 - `UserSetting.contentRetentionDays` を参照して削除基準日を計算し、基準日より古い `Content` を物理削除する
 - **削除基準日時**:
   - `type=VIDEO`: `publishedAt`（NULL の場合は `createdAt` にフォールバック）
-  - `type=LIVE`: `scheduledStartAt`（NULL の場合は `createdAt` にフォールバック）
+  - `type=LIVE`: `actualStartAt`（NULL の場合は `scheduledStartAt`、それも NULL の場合は `createdAt` にフォールバック）
 - **削除対象外**: `status=LIVE`（配信中）のコンテンツは削除しない
 - **「後で見る」フラグの扱い**: フラグON（`removedVia IS NULL`）のコンテンツも例外なく削除対象とする
 - `WatchLater` は `Content.onDelete: Cascade` により自動削除されるため、個別削除は不要


### PR DESCRIPTION
## Summary

- `type=LIVE` コンテンツの ContentCleanup 削除基準日時を `scheduledStartAt` から `actualStartAt` 優先に変更
- フォールバック順: `actualStartAt` → `scheduledStartAt` → `createdAt`

## 背景

配信が大幅に延期された場合、`scheduledStartAt` 基準だと配信直後のコンテンツが保持期間超過で削除される可能性があった。`actualStartAt`（実際の配信開始時刻）を優先することで、実際に配信されたタイミングからの保持期間が保証される。

## 変更内容

- `docs/architecture.md` §6 ContentCleanup の `type=LIVE` 削除基準日時の定義を更新

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)