### PR TITLE
docs: Vitestテストフレームワーク導入方針をCLAUDE.mdに追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ For endpoint costs and full quota reference, see [`ref/youtube-api.md`](ref/yout
   - `src/app/api/categories/route.ts` → `src/app/api/categories/route.test.ts`
   - `src/jobs/contentCleanup.ts` → `src/jobs/contentCleanup.test.ts`
 
-### Shared Test Infrastructure (set up in T01)
+### Shared Test Infrastructure
 
 - `src/tests/setup.ts` — Global setup
 - `src/tests/helpers/prisma-mock.ts` — `mockDeep<PrismaClient>()` factory


### PR DESCRIPTION
## Summary

- テストフレームワークを「導入しない」から **Vitest** に方針変更
- `CLAUDE.md` に `## Testing` セクションを新規追加し、AIエージェントがテストを実装する際の指針を定義

## 変更内容

- **Testing Strategy**: テストランナー（Vitest）、対象スコープ（`src/lib/`・`src/app/api/`）、Prisma/Authモック方針を明記
- **ファイル命名規則**: ソースファイルと同階層にコロケート、`{source}.test.ts` 命名
- **共通テストインフラ**: T01で整備する `src/tests/` 以下のヘルパーファイル構成
- **テストコマンド**: `npx vitest run` / `npx vitest` / `npx vitest run --coverage`
- **テスト作成タイミング**: 必須ケース（`src/lib/`のビジネスロジック、コアAPIルート、`src/jobs/`の日付/条件ロジック）と免除ケース（Worker エントリーポイント、UIコンポーネント等）

> Note: `work/development-plan.md` は `.gitignore` 対象のため別途ローカルで更新済み。

## Test plan

- [ ] CLAUDE.md の `## Testing` セクションが正しく表示されること
- [ ] 既存の他セクションとの整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)