### PR TITLE
refactor: 設定APIのバリデーションヘルパー追加とDBクエリ並列化

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from 'next/server'
 
-import { getAuthenticatedSession, isValidPollingInterval } from '@/lib/api-helpers'
+import {
+  getAuthenticatedSession,
+  isValidContentRetentionDays,
+  isValidPollingInterval,
+} from '@/lib/api-helpers'
 import {
   DEFAULT_CONTENT_RETENTION_DAYS,
   DEFAULT_POLLING_INTERVAL_MINUTES,
-  VALID_CONTENT_RETENTION_DAYS,
   YOUTUBE_QUOTA_DAILY_LIMIT,
   YOUTUBE_QUOTA_WARNING_THRESHOLD,
 } from '@/lib/config'
@@ -20,19 +23,17 @@ export async function GET() {
   }
 
   try {
-    // UserSetting を取得（存在しない場合は upsert でデフォルト値で自動生成）
-    const userSetting = await prisma.userSetting.upsert({
-      where: { userId: auth.userId },
-      update: {},
-      create: {
-        userId: auth.userId,
-        pollingIntervalMinutes: DEFAULT_POLLING_INTERVAL_MINUTES,
-        contentRetentionDays: DEFAULT_CONTENT_RETENTION_DAYS,
-      },
-    })
-
-    // カテゴリデータとアカウント情報を並列取得
-    const [categories, account] = await Promise.all([
+    // UserSetting・カテゴリデータ・アカウント情報を並列取得
+    const [userSetting, categories, account] = await Promise.all([
+      prisma.userSetting.upsert({
+        where: { userId: auth.userId },
+        update: {},
+        create: {
+          userId: auth.userId,
+          pollingIntervalMinutes: DEFAULT_POLLING_INTERVAL_MINUTES,
+          contentRetentionDays: DEFAULT_CONTENT_RETENTION_DAYS,
+        },
+      }),
       prisma.category.findMany({
         where: { userId: auth.userId },
         include: {
@@ -112,10 +113,7 @@ export async function PATCH(request: Request) {
     }
 
     // Validate contentRetentionDays
-    if (
-      contentRetentionDays !== undefined &&
-      !(VALID_CONTENT_RETENTION_DAYS as readonly number[]).includes(contentRetentionDays)
-    ) {
+    if (contentRetentionDays !== undefined && !isValidContentRetentionDays(contentRetentionDays)) {
       return errorResponse(
         ErrorCode.INVALID_RETENTION_DAYS,
         'コンテンツ保持期間が不正です。30, 60, 90, 180, 365 のいずれかを指定してください',

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -1,7 +1,7 @@
 import { getServerSession, type Session } from 'next-auth'
 
 import { authOptions } from '@/lib/auth'
-import { VALID_POLLING_INTERVALS } from '@/lib/config'
+import { VALID_CONTENT_RETENTION_DAYS, VALID_POLLING_INTERVALS } from '@/lib/config'
 
 /**
  * 認証済みセッションを取得する。
@@ -32,6 +32,15 @@ export function isValidPollingInterval(
   value: unknown,
 ): value is (typeof VALID_POLLING_INTERVALS)[number] {
   return (VALID_POLLING_INTERVALS as readonly unknown[]).includes(value)
+}
+
+/**
+ * コンテンツ保持期間値が有効値（VALID_CONTENT_RETENTION_DAYS）に含まれるか検証する型ガード
+ */
+export function isValidContentRetentionDays(
+  value: unknown,
+): value is (typeof VALID_CONTENT_RETENTION_DAYS)[number] {
+  return (VALID_CONTENT_RETENTION_DAYS as readonly unknown[]).includes(value)
 }
 
 /**


### PR DESCRIPTION
## Summary
- `isValidContentRetentionDays()` 型ガードを `api-helpers.ts` に追加し、`isValidPollingInterval()` とパターンを統一
- GET ハンドラの `userSetting` upsert を `Promise.all` に統合し、3つのDBクエリを並列実行するよう改善

## Test plan
- [x] `npx vitest run src/app/api/settings/` — 既存テスト6件すべて合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)