### PR TITLE
feat: 設定画面を実装 #85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@prisma/client": "^5.22.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",
@@ -2799,6 +2801,12 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -3085,6 +3093,52 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-menu": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
@@ -3295,6 +3349,67 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -3398,6 +3513,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
@@ -3430,6 +3560,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.90.21",
     "class-variance-authority": "^0.7.1",

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,5 @@
+import { SettingsPage } from '@/components/features/settings/SettingsPage'
+
+export default function SettingsRoute() {
+  return <SettingsPage />
+}

--- a/src/components/features/settings/AccountSection.tsx
+++ b/src/components/features/settings/AccountSection.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { signIn } from 'next-auth/react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import type { UserSettingsResponse } from '@/types/api'
+
+type Props = {
+  settings: UserSettingsResponse
+}
+
+export function AccountSection({ settings }: Props) {
+  const [isLoading, setIsLoading] = useState(false)
+  const isValid = settings.tokenStatus === 'valid'
+
+  const handleReauth = async () => {
+    setIsLoading(true)
+    await signIn('google', { callbackUrl: '/settings' })
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4">アカウント</h2>
+      <div className="border-t pt-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">認証状態</span>
+          <span className="ml-auto flex items-center gap-1.5">
+            {isValid ? (
+              <>
+                <span className="h-2 w-2 rounded-full bg-green-500" />
+                <span className="text-sm font-medium">認証済み</span>
+              </>
+            ) : (
+              <>
+                <AlertTriangle className="h-4 w-4 text-orange-500" />
+                <span className="text-sm font-medium text-orange-500">要再認証</span>
+              </>
+            )}
+          </span>
+        </div>
+
+        {!isValid && (
+          <div className="mt-4 space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Google アカウントとの連携が切れています。
+              <br />
+              再認証しないとポーリングが動作しません。
+            </p>
+            <Button onClick={handleReauth} disabled={isLoading}>
+              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              再認証する
+            </Button>
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/features/settings/ChannelSyncSection.tsx
+++ b/src/components/features/settings/ChannelSyncSection.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useState } from 'react'
+import { CheckCircle, Loader2 } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { useSyncChannels, type SyncChannelsResponse } from '@/hooks/useSettings'
+
+export function ChannelSyncSection() {
+  const syncChannels = useSyncChannels()
+  const [syncResult, setSyncResult] = useState<SyncChannelsResponse | null>(null)
+
+  const handleSync = () => {
+    setSyncResult(null)
+    syncChannels.mutate(undefined, {
+      onSuccess: (data) => {
+        setSyncResult(data)
+      },
+    })
+  }
+
+  const formatResult = (result: SyncChannelsResponse): string => {
+    const { added, restored, deactivated, updated } = result
+    if (added === 0 && restored === 0 && deactivated === 0 && updated === 0) {
+      return '変更はありませんでした'
+    }
+    return `追加 ${added}件 / 復元 ${restored}件 / 無効化 ${deactivated}件 / 更新 ${updated}件`
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4">チャンネル同期</h2>
+      <div className="border-t pt-4 space-y-3">
+        <p className="text-sm text-muted-foreground">
+          YouTubeでのチャンネル登録・解除はここから同期できます。
+          <br />
+          定期ポーリングではチャンネル一覧は自動更新されません。
+        </p>
+
+        <Button onClick={handleSync} disabled={syncChannels.isPending}>
+          {syncChannels.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {syncChannels.isPending ? '同期中...' : 'チャンネルを再同期する'}
+        </Button>
+
+        {syncResult && (
+          <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <CheckCircle className="h-4 w-4 text-green-500" />
+            {formatResult(syncResult)}
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/features/settings/ContentSection.tsx
+++ b/src/components/features/settings/ContentSection.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useUpdateSettings } from '@/hooks/useSettings'
+import type { UserSettingsResponse } from '@/types/api'
+
+const RETENTION_OPTIONS = [
+  { label: '1ヶ月', value: '30' },
+  { label: '2ヶ月（デフォルト）', value: '60' },
+  { label: '3ヶ月', value: '90' },
+  { label: '6ヶ月', value: '180' },
+  { label: '1年', value: '365' },
+] as const
+
+type Props = {
+  settings: UserSettingsResponse
+}
+
+export function ContentSection({ settings }: Props) {
+  const updateSettings = useUpdateSettings()
+
+  const handleRetentionChange = (value: string) => {
+    updateSettings.mutate({ contentRetentionDays: Number(value) })
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4">コンテンツ設定</h2>
+      <div className="border-t pt-4">
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-sm text-muted-foreground">コンテンツ保持期間</span>
+          <Select
+            value={String(settings.contentRetentionDays)}
+            onValueChange={handleRetentionChange}
+            disabled={updateSettings.isPending}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {RETENTION_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <p className="text-xs text-muted-foreground mt-1">
+          指定期間を超えた動画・ライブ履歴を自動削除します。
+          <br />
+          変更は次回の自動削除処理（毎日1回）から反映されます。
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/src/components/features/settings/NotificationSection.tsx
+++ b/src/components/features/settings/NotificationSection.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { Loader2, X } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { useRegisterPushSubscription, useSendTestNotification } from '@/hooks/useSettings'
+
+type NotificationStatus = 'loading' | 'enabled' | 'not-enabled' | 'denied'
+
+export function NotificationSection() {
+  const [status, setStatus] = useState<NotificationStatus>('loading')
+  const [isEnabling, setIsEnabling] = useState(false)
+  const registerSubscription = useRegisterPushSubscription()
+  const sendTest = useSendTestNotification()
+
+  const checkStatus = useCallback(async () => {
+    // Check if Notification API is available
+    if (typeof window === 'undefined' || !('Notification' in window)) {
+      setStatus('not-enabled')
+      return
+    }
+
+    const permission = Notification.permission
+
+    if (permission === 'denied') {
+      setStatus('denied')
+      return
+    }
+
+    if (permission === 'granted') {
+      // Check if service worker subscription exists
+      try {
+        const registration = await navigator.serviceWorker?.ready
+        const subscription = await registration?.pushManager?.getSubscription()
+        setStatus(subscription ? 'enabled' : 'not-enabled')
+      } catch {
+        setStatus('not-enabled')
+      }
+      return
+    }
+
+    // permission === 'default'
+    setStatus('not-enabled')
+  }, [])
+
+  useEffect(() => {
+    checkStatus()
+  }, [checkStatus])
+
+  const handleEnable = async () => {
+    setIsEnabling(true)
+    try {
+      const permission = await Notification.requestPermission()
+
+      if (permission === 'denied') {
+        setStatus('denied')
+        setIsEnabling(false)
+        return
+      }
+
+      if (permission === 'granted') {
+        const registration = await navigator.serviceWorker.ready
+        const subscription = await registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+        })
+
+        const json = subscription.toJSON()
+        await registerSubscription.mutateAsync({
+          endpoint: subscription.endpoint,
+          p256dh: json.keys?.p256dh ?? '',
+          auth: json.keys?.auth ?? '',
+          userAgent: navigator.userAgent,
+        })
+
+        setStatus('enabled')
+      }
+    } catch (error) {
+      console.error('[NotificationSection] Enable failed:', error)
+      toast.error('通知の有効化に失敗しました')
+      setStatus('not-enabled')
+    } finally {
+      setIsEnabling(false)
+    }
+  }
+
+  if (status === 'loading') {
+    return (
+      <section>
+        <h2 className="text-lg font-semibold mb-4">通知設定</h2>
+        <div className="border-t pt-4">
+          <div className="h-8 w-32 animate-pulse rounded bg-muted" />
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4">通知設定</h2>
+      <div className="border-t pt-4 space-y-3">
+        {/* Status display */}
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">通知の状態</span>
+          <span className="ml-auto flex items-center gap-1.5">
+            {status === 'enabled' && (
+              <>
+                <span className="h-2 w-2 rounded-full bg-green-500" />
+                <span className="text-sm font-medium">有効化済み</span>
+              </>
+            )}
+            {status === 'not-enabled' && (
+              <>
+                <span className="h-2 w-2 rounded-full bg-gray-400" />
+                <span className="text-sm font-medium text-muted-foreground">未有効化</span>
+              </>
+            )}
+            {status === 'denied' && (
+              <>
+                <X className="h-3.5 w-3.5 text-red-500" />
+                <span className="text-sm font-medium text-red-500">拒否済み</span>
+              </>
+            )}
+          </span>
+        </div>
+
+        {/* Status-specific content */}
+        {status === 'enabled' && (
+          <Button
+            variant="outline"
+            onClick={() => sendTest.mutate()}
+            disabled={sendTest.isPending}
+          >
+            {sendTest.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            テスト通知を送信する
+          </Button>
+        )}
+
+        {status === 'not-enabled' && (
+          <>
+            <p className="text-sm text-muted-foreground">
+              ブラウザのWeb Push通知を有効化すると、新着動画・ライブ配信を
+              リアルタイムで受け取ることができます。
+            </p>
+            <Button onClick={handleEnable} disabled={isEnabling}>
+              {isEnabling && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              通知を有効化する
+            </Button>
+          </>
+        )}
+
+        {status === 'denied' && (
+          <p className="text-sm text-muted-foreground">
+            ブラウザの設定で通知が拒否されています。
+            <br />
+            ブラウザの設定から通知を許可してください。
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/features/settings/PollingSection.tsx
+++ b/src/components/features/settings/PollingSection.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { AlertCircle } from 'lucide-react'
+
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useUpdateSettings } from '@/hooks/useSettings'
+import type { UserSettingsResponse } from '@/types/api'
+
+const POLLING_INTERVAL_OPTIONS = [
+  { label: '5分', value: '5' },
+  { label: '10分', value: '10' },
+  { label: '30分（デフォルト）', value: '30' },
+  { label: '1時間', value: '60' },
+] as const
+
+type Props = {
+  settings: UserSettingsResponse
+}
+
+export function PollingSection({ settings }: Props) {
+  const updateSettings = useUpdateSettings()
+
+  const handleIntervalChange = (value: string) => {
+    updateSettings.mutate({ pollingIntervalMinutes: Number(value) })
+  }
+
+  const isQuotaExhausted = settings.quotaExhaustedUntil != null
+  const isQuotaWarning = settings.estimatedDailyQuota > settings.quotaWarningThreshold
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4">ポーリング設定</h2>
+      <div className="border-t pt-4 space-y-4">
+        {/* Quota exhausted banner */}
+        {isQuotaExhausted && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              YouTube API クォータが本日分を超過しました。
+              <br />
+              ポーリングは翌日 UTC 00:00 に自動再開します。（日本時間 09:00 頃）
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {/* Polling interval select */}
+        <div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-sm text-muted-foreground">デフォルトポーリング間隔</span>
+            <Select
+              value={String(settings.pollingIntervalMinutes)}
+              onValueChange={handleIntervalChange}
+              disabled={updateSettings.isPending}
+            >
+              <SelectTrigger className="w-[200px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {POLLING_INTERVAL_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">
+            カテゴリごとに上書きしない場合に使用されるデフォルト間隔。
+            <br />
+            変更は次のポーリングサイクル開始時から反映されます。
+          </p>
+        </div>
+
+        {/* Quota usage display */}
+        <p className="text-sm">
+          推定1日クォータ使用量:{' '}
+          <span className={isQuotaWarning ? 'font-semibold text-orange-500' : 'font-medium'}>
+            {settings.estimatedDailyQuota.toLocaleString()}
+          </span>{' '}
+          / {settings.quotaDailyLimit.toLocaleString()} units
+        </p>
+
+        {/* Quota warning */}
+        {isQuotaWarning && (
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              全カテゴリの合計クォータが警告しきい値を超えています。
+              <br />
+              一部のカテゴリのポーリング間隔を長くすることを推奨します。
+            </AlertDescription>
+          </Alert>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/features/settings/SettingsPage.tsx
+++ b/src/components/features/settings/SettingsPage.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { AlertCircle, RefreshCw } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useSettings } from '@/hooks/useSettings'
+
+import { AccountSection } from './AccountSection'
+import { ChannelSyncSection } from './ChannelSyncSection'
+import { ContentSection } from './ContentSection'
+import { NotificationSection } from './NotificationSection'
+import { PollingSection } from './PollingSection'
+
+function SettingsSkeleton() {
+  return (
+    <div className="space-y-8">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <div key={i} className="space-y-4">
+          <Skeleton className="h-6 w-32" />
+          <div className="border-t pt-4">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-9 w-[200px]" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function SettingsPage() {
+  const { data: settings, isLoading, isError, refetch } = useSettings()
+
+  return (
+    <main className="mx-auto max-w-[640px] p-4">
+      <h1 className="text-2xl font-bold mb-6">設定</h1>
+
+      {isLoading ? (
+        <SettingsSkeleton />
+      ) : isError ? (
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-destructive/50 bg-destructive/10 py-8 text-center">
+          <AlertCircle className="h-8 w-8 text-destructive" />
+          <p className="text-sm text-destructive">
+            設定の取得に失敗しました。ページを再読み込みしてください。
+          </p>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            再読み込み
+          </Button>
+        </div>
+      ) : settings ? (
+        <div className="space-y-8">
+          <AccountSection settings={settings} />
+          <PollingSection settings={settings} />
+          <ContentSection settings={settings} />
+          <ChannelSyncSection />
+          <NotificationSection />
+        </div>
+      ) : null}
+    </main>
+  )
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 
 import { apiFetch } from '@/lib/api-client'
 import type { UserSettingsResponse } from '@/types/api'
@@ -7,5 +8,85 @@ export function useSettings() {
   return useQuery<UserSettingsResponse>({
     queryKey: ['settings'],
     queryFn: () => apiFetch<UserSettingsResponse>('/api/settings'),
+  })
+}
+
+export function useUpdateSettings() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: { pollingIntervalMinutes?: number; contentRetentionDays?: number }) =>
+      apiFetch<{ pollingIntervalMinutes: number; contentRetentionDays: number }>('/api/settings', {
+        method: 'PATCH',
+        body: JSON.stringify(data),
+      }),
+    onMutate: async (data) => {
+      await queryClient.cancelQueries({ queryKey: ['settings'] })
+      const previous = queryClient.getQueryData<UserSettingsResponse>(['settings'])
+
+      if (previous) {
+        queryClient.setQueryData<UserSettingsResponse>(['settings'], {
+          ...previous,
+          ...data,
+        })
+      }
+
+      return { previous }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(['settings'], context.previous)
+      }
+      toast.error('設定の保存に失敗しました')
+    },
+    onSuccess: () => {
+      toast.success('設定を保存しました')
+      // Re-fetch to get updated estimatedDailyQuota from server
+      queryClient.invalidateQueries({ queryKey: ['settings'] })
+    },
+  })
+}
+
+export type SyncChannelsResponse = {
+  added: number
+  restored: number
+  deactivated: number
+  updated: number
+}
+
+export function useSyncChannels() {
+  return useMutation({
+    mutationFn: () =>
+      apiFetch<SyncChannelsResponse>('/api/settings/sync-channels', {
+        method: 'POST',
+      }),
+    onError: () => {
+      toast.error('チャンネルの同期に失敗しました')
+    },
+  })
+}
+
+export function useRegisterPushSubscription() {
+  return useMutation({
+    mutationFn: (data: { endpoint: string; p256dh: string; auth: string; userAgent?: string }) =>
+      apiFetch<{ id: string; endpoint: string }>('/api/notifications/subscriptions', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+  })
+}
+
+export function useSendTestNotification() {
+  return useMutation({
+    mutationFn: () =>
+      apiFetch<{ sent: number; failed: number }>('/api/notifications/test', {
+        method: 'POST',
+      }),
+    onSuccess: () => {
+      toast.success('テスト通知を送信しました。デバイスに通知が届いているか確認してください。')
+    },
+    onError: () => {
+      toast.error('通知の送信に失敗しました')
+    },
   })
 }


### PR DESCRIPTION
Closes #85

## 概要
設定画面の全セクションをUIで実装。

- **アカウントセクション**: tokenStatus表示（認証済み/要再認証）、再認証ボタン
- **ポーリング設定**: デフォルトポーリング間隔Dropdown、クォータ使用量表示、クォータ警告/枯渇バナー
- **コンテンツ設定**: コンテンツ保持期間Dropdown
- **チャンネル同期**: 再同期ボタン（スタブ、T19で完成）、同期結果表示
- **通知設定**: ブラウザPermission判定、有効化/テスト通知ボタン（サーバーAPIはT24で接続）

## 追加ファイル
- `src/app/(dashboard)/settings/page.tsx` — 設定ページルート
- `src/components/features/settings/` — 各セクションコンポーネント（5ファイル）
- `src/components/ui/` — shadcn/ui コンポーネント追加（alert, card, label, select）
- `src/hooks/useSettings.ts` — 設定関連のカスタムフック拡張

## テスト結果
- `npx vitest run`: 7ファイル / 103テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)