### PR TITLE
chore: PRレビュー対応方針をCLAUDE.mdに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,16 @@ The `docs/` specs must be written so that Claude Code can implement them without
 4. **Confirm before creating or modifying specs**: When creating a new `docs/` file or making non-trivial edits to existing ones, always confirm the intended direction with the developer first.
 5. **Keep specs and code in sync**: When a spec change is decided during implementation, update the relevant `docs/` files in the same commit or PR as the code change. Never let specs and code diverge.
 
+### PR Review Response Policy
+
+When responding to PR review comments:
+
+1. **Do not blindly accept suggestions**: Reviewer comments are input, not instructions. Evaluate each comment on its merits.
+2. **Assess validity first**: For each comment, judge whether the concern is valid given the codebase context, specs, and design decisions.
+3. **Determine your own fix approach**: Even if the reviewer proposes a specific fix, independently decide the best implementation approach. The reviewer's suggestion may be suboptimal, incomplete, or based on incomplete context.
+4. **Communicate your reasoning**: If you disagree with a comment or choose a different approach than suggested, explain why before implementing.
+5. **Flag spec conflicts**: If acting on a review comment would conflict with `docs/` specs or `CLAUDE.md` rules, flag it explicitly rather than silently choosing one over the other.
+
 ### Git Workflow
 
 - **Feature branches**: Create a branch per feature, merge to main when complete.


### PR DESCRIPTION
## Summary

- PRレビューコメントを鵜呑みにせず、妥当性を評価したうえで修正方針を決めるルールを `CLAUDE.md` の Development Workflow セクションに追加
- 「PR Review Response Policy」として5つの行動原則を明文化

## 背景

レビュアーの提案が常に最適とは限らない。コードベースや仕様を把握していない状態での提案に引きずられると品質が下がる可能性があるため、Claude Code がレビュー対応時に取るべきスタンスを明示した。

## 変更内容

`CLAUDE.md` に以下を追加:
1. レビューコメントを盲目的に受け入れない
2. 妥当性を評価してから判断する
3. 修正アプローチは自分で決める
4. 異なるアプローチを取る場合は理由を説明する
5. spec との矛盾があれば明示的にフラグを立てる

🤖 Generated with [Claude Code](https://claude.ai/claude-code)