### PR TITLE
feat: サイドバーのカテゴリ一覧にポーリング状態アイコンを表示

### DIFF
--- a/src/components/features/dashboard/CategoryNav.tsx
+++ b/src/components/features/dashboard/CategoryNav.tsx
@@ -1,7 +1,12 @@
+'use client'
+
+import { Clock, TimerOff } from 'lucide-react'
+
+import { useSettings } from '@/hooks/useSettings'
 import { cn } from '@/lib/utils'
 import { UNCATEGORIZED_CATEGORY_ID } from '@/lib/config'
 import { Separator } from '@/components/ui/separator'
-import type { CategoryResponse } from '@/types/api'
+import type { CategoryResponse, NotificationSettingResponse } from '@/types/api'
 
 type CategoryNavProps = {
   categories: CategoryResponse[]
@@ -9,11 +14,56 @@ type CategoryNavProps = {
   onSelectCategory: (categoryId: string) => void
 }
 
+type PollingIconProps = {
+  settings: NotificationSettingResponse | null
+  globalIntervalMinutes: number | undefined
+  isUncategorized?: boolean
+}
+
+function PollingIcon({ settings, globalIntervalMinutes, isUncategorized }: PollingIconProps) {
+  if (isUncategorized) {
+    return (
+      <span title="自動ポーリング: 無効（未分類チャンネルは対象外）" className="shrink-0">
+        <TimerOff className="h-3.5 w-3.5 text-muted-foreground" />
+      </span>
+    )
+  }
+
+  if (settings === null) {
+    return null
+  }
+
+  if (!settings.autoPollingEnabled) {
+    return (
+      <span title="自動ポーリング: 無効（手動のみ）" className="shrink-0">
+        <TimerOff className="h-3.5 w-3.5 text-muted-foreground" />
+      </span>
+    )
+  }
+
+  if (settings.pollingIntervalMinutes !== null) {
+    return (
+      <span title={`自動ポーリング: ${settings.pollingIntervalMinutes}分ごと`} className="shrink-0">
+        <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+      </span>
+    )
+  }
+
+  const globalInterval = globalIntervalMinutes !== undefined ? `${globalIntervalMinutes}分` : '-'
+  return (
+    <span title={`自動ポーリング: グローバル設定（${globalInterval}）`} className="shrink-0">
+      <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+    </span>
+  )
+}
+
 export function CategoryNav({
   categories,
   selectedCategoryId,
   onSelectCategory,
 }: CategoryNavProps) {
+  const { data: settings } = useSettings()
+
   return (
     <nav className="flex flex-col py-2">
       {categories.map((category) => (
@@ -21,22 +71,27 @@ export function CategoryNav({
           key={category.id}
           onClick={() => onSelectCategory(category.id)}
           className={cn(
-            'truncate px-4 py-2 text-left text-sm transition-colors hover:bg-accent',
+            'flex items-center gap-1 px-4 py-2 text-left text-sm transition-colors hover:bg-accent',
             selectedCategoryId === category.id && 'bg-accent font-medium',
           )}
         >
-          {category.name}
+          <span className="flex-1 truncate">{category.name}</span>
+          <PollingIcon
+            settings={category.settings}
+            globalIntervalMinutes={settings?.pollingIntervalMinutes}
+          />
         </button>
       ))}
       <Separator className="my-1" />
       <button
         onClick={() => onSelectCategory(UNCATEGORIZED_CATEGORY_ID)}
         className={cn(
-          'truncate px-4 py-2 text-left text-sm transition-colors hover:bg-accent',
+          'flex items-center gap-1 px-4 py-2 text-left text-sm transition-colors hover:bg-accent',
           selectedCategoryId === UNCATEGORIZED_CATEGORY_ID && 'bg-accent font-medium',
         )}
       >
-        未分類
+        <span className="flex-1 truncate">未分類</span>
+        <PollingIcon settings={null} globalIntervalMinutes={undefined} isUncategorized />
       </button>
     </nav>
   )


### PR DESCRIPTION
## 概要

Closes #142

サイドバーの `CategoryNav` に各カテゴリのポーリング状態アイコンを追加しました。

## 対応内容

- `CategoryNav.tsx` に `PollingIcon` コンポーネントを追加
- 各カテゴリの `settings.autoPollingEnabled` / `settings.pollingIntervalMinutes` に基づいてアイコンを分岐表示
- `useSettings()` でグローバル設定間隔を取得（TanStack Query キャッシュにより追加APIコール不要）

## アイコン状態

| 状態 | アイコン | ツールチップ |
|------|---------|------------|
| ポーリング ON（個別間隔） | Clock | `自動ポーリング: X分ごと` |
| ポーリング ON（グローバル設定） | Clock | `自動ポーリング: グローバル設定（X分）` |
| ポーリング OFF | TimerOff | `自動ポーリング: 無効（手動のみ）` |
| 未分類 | TimerOff | `自動ポーリング: 無効（未分類チャンネルは対象外）` |
| settings=null（通常非発生） | なし | — |

## 実装のポイント

- ツールチップ: `<span title>` ラッパーを使用（既存の `PollButton.tsx` と同様のHTML tooltip パターン、lucide の `title` prop は SVG `<title>` 要素を生成するため別物）
- レイアウト: `<button>` を flex にして `カテゴリ名（flex-1 truncate）+ アイコン（shrink-0）` でカテゴリ名が極端に狭くならないよう対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)