### PR TITLE
refactor: CategoryResponse.settings の null 許容型を修正 #145

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -51,7 +51,7 @@ components:
           format: date-time
         settings:
           $ref: '#/components/schemas/NotificationSetting'
-      required: [id, name, sortOrder, createdAt, updatedAt]
+      required: [id, name, sortOrder, createdAt, updatedAt, settings]
 
     # --- Channel ---
     Channel:

--- a/src/app/api/categories/helpers.test.ts
+++ b/src/app/api/categories/helpers.test.ts
@@ -121,13 +121,4 @@ describe('formatCategory', () => {
     expect(result).not.toHaveProperty('notificationSetting')
   })
 
-  it('notificationSettingがnullの場合、settingsがnullになる', () => {
-    const category = {
-      ...makeCategory(),
-      notificationSetting: null,
-    }
-    const result = formatCategory(category)
-
-    expect(result.settings).toBeNull()
-  })
 })

--- a/src/app/api/categories/helpers.ts
+++ b/src/app/api/categories/helpers.ts
@@ -2,8 +2,10 @@ import type { Category, NotificationSetting } from '@prisma/client'
 
 import type { CategoryResponse, NotificationSettingResponse } from '@/types/api'
 
+// Prisma's 1:1 relation include returns `T | null`, but notificationSetting
+// is always created alongside the category in a transaction, so it is never null at runtime.
 export type CategoryWithNotificationSetting = Category & {
-  notificationSetting: NotificationSetting | null
+  notificationSetting: NotificationSetting
 }
 
 /**
@@ -34,8 +36,6 @@ export function formatCategory(category: CategoryWithNotificationSetting): Categ
     sortOrder: category.sortOrder,
     createdAt: category.createdAt.toISOString(),
     updatedAt: category.updatedAt.toISOString(),
-    settings: category.notificationSetting
-      ? formatNotificationSetting(category.notificationSetting)
-      : null,
+    settings: formatNotificationSetting(category.notificationSetting),
   }
 }

--- a/src/components/features/categories/CategoryRow.tsx
+++ b/src/components/features/categories/CategoryRow.tsx
@@ -204,13 +204,11 @@ export function CategoryRow({ category, isDndDisabled, globalPollingInterval }: 
         </div>
 
         <CollapsibleContent>
-          {category.settings && (
-            <CategorySettings
-              categoryId={category.id}
-              settings={category.settings}
-              globalPollingInterval={globalPollingInterval}
-            />
-          )}
+          <CategorySettings
+            categoryId={category.id}
+            settings={category.settings}
+            globalPollingInterval={globalPollingInterval}
+          />
         </CollapsibleContent>
       </Collapsible>
 

--- a/src/components/features/dashboard/CategoryNav.tsx
+++ b/src/components/features/dashboard/CategoryNav.tsx
@@ -74,8 +74,8 @@ export function CategoryNav({
   return (
     <nav className="flex flex-col py-2">
       {categories.map((category) => {
-        const autoPollingEnabled = category.settings?.autoPollingEnabled ?? true
-        const pollingIntervalMinutes = category.settings?.pollingIntervalMinutes ?? null
+        const autoPollingEnabled = category.settings.autoPollingEnabled
+        const pollingIntervalMinutes = category.settings.pollingIntervalMinutes
 
         return (
           <button

--- a/src/hooks/useCategorySettings.ts
+++ b/src/hooks/useCategorySettings.ts
@@ -32,7 +32,7 @@ export function useCategorySettings() {
 
       if (previous) {
         const updated = previous.map((cat) => {
-          if (cat.id === categoryId && cat.settings) {
+          if (cat.id === categoryId) {
             return {
               ...cat,
               settings: {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -47,7 +47,7 @@ export type CategoryResponse = {
   sortOrder: number
   createdAt: string
   updatedAt: string
-  settings: NotificationSettingResponse | null
+  settings: NotificationSettingResponse
 }
 
 // --- Channel ---


### PR DESCRIPTION
Closes #145

## 対応内容

`CategoryResponse.settings` の型から `| null` を除去し、不要な null チェックを全面的に除去するリファクタリング。

カテゴリ作成時に `notificationSetting` はトランザクションで必ず同時作成されるため、実行時に `null` になることはない。この不変条件を型システムに反映させた。

## 変更箇所

- `docs/openapi.yaml` — `settings` を `required` に追加
- `src/types/api.ts` — `settings` の型から `| null` を除去
- `src/app/api/categories/helpers.ts` — `CategoryWithNotificationSetting` 型と `formatCategory` の null チェック除去
- `src/app/api/categories/helpers.test.ts` — null ケースのテスト削除
- `src/components/features/dashboard/CategoryNav.tsx` — `settings?.` → `settings.` に変更
- `src/components/features/categories/CategoryRow.tsx` — null ガード除去
- `src/hooks/useCategorySettings.ts` — `&& cat.settings` 条件除去

## 対応方針

- Prisma の 1:1 リレーションは型上 `T | null` を返すため、`route.ts` の `as CategoryWithNotificationSetting` キャストは維持（コメントで理由を明記）
- モノリス構成のため外部 API コンシューマーへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)