### PR TITLE
fix: start.ps1 を UTF-8 BOM 付きで保存し Windows PowerShell 5.1 で実行可能にする

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # start.ps1 - MySubChs 開発環境起動スクリプト
 #
 # 処理フロー:


### PR DESCRIPTION
## Summary

- `start.ps1` を **UTF-8 BOM 付き** で保存し直した（スクリプト本体の内容・LF 改行は変更なし）。
- 目的: `powershell` コマンド（Windows PowerShell 5.1）からでも起動できるようにする。

## 背景 / なぜ必要か

`powershell -ExecutionPolicy Bypass -File .\start.ps1` 実行時に、93/95/150 行目付近で「`}` を使用できません」「ブロックの終わりが見つからない」系のパースエラーが発生する事象があった。

原因はエンコーディングと PowerShell バージョンの不一致:

- `start.ps1` は **UTF-8 (BOMなし)** で保存されていた。
- **Windows PowerShell 5.1** は BOM なしスクリプトを ANSI コードページ（日本語環境では CP932 = Shift-JIS）として読む仕様。
- ファイル内の日本語コメントを Shift-JIS として再解釈すると、2バイト目に `{` / `}` / バッククオートに相当するバイトが混入し、ブロック構造の対応が崩れてパースエラーになる。
- PowerShell 7+ (`pwsh`) は BOM なしでも UTF-8 として読むため発生しなかった。

BOM (`EF BB BF`) を付与することで、Windows PowerShell 5.1 / PowerShell 7+ のどちらからでも UTF-8 として正しく読まれる。

## 変更内容

- `start.ps1` の先頭に UTF-8 BOM を付与（1行 +1/-1 の diff、コード変更なし）

## Test plan

- [ ] `powershell -ExecutionPolicy Bypass -File .\start.ps1` を **main 以外のブランチ**で実行 → 「現在のブランチは '...' です。」の日本語メッセージが文字化けせず表示され、exit 1 で終了
- [ ] `pwsh -ExecutionPolicy Bypass -File .\start.ps1` でも同様に動作すること（リグレッションがないこと）
- [ ] `od -An -tx1 -N3 start.ps1` が `ef bb bf` を返すこと
- [ ] 改行コードが LF のまま保たれていること（`grep -c $'\r' start.ps1` が 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)