### PR TITLE
fix: 起動時にnpm installを実行して依存追加を自動同期 #172

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - /app/.next
     env_file:
       - .env
-    command: sh -c "npx prisma generate && npm run dev"
+    command: sh -c "npm install && npx prisma generate && npm run dev"
     depends_on:
       db:
         condition: service_healthy
@@ -29,7 +29,7 @@ services:
       - /app/node_modules
     env_file:
       - .env
-    command: sh -c "npx prisma generate && npx tsx src/jobs/worker.ts"
+    command: sh -c "npm install && npx prisma generate && npx tsx src/jobs/worker.ts"
     depends_on:
       db:
         condition: service_healthy

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -20,7 +20,7 @@ services:
       - /app/.next
     env_file:
       - .env
-    command: npm run dev
+    command: sh -c "npm install && npx prisma generate && npm run dev"
     depends_on:
       db:
         condition: service_healthy
@@ -38,7 +38,7 @@ services:
       - /app/node_modules
     env_file:
       - .env
-    command: npx tsx src/jobs/worker.ts
+    command: sh -c "npm install && npx prisma generate && npx tsx src/jobs/worker.ts"
     depends_on:
       db:
         condition: service_healthy
@@ -94,6 +94,7 @@ networks:
 - `db` / `redis` はヘルスチェックが成功するまで `app` / `worker` の起動を待機する（`depends_on` + `condition: service_healthy`）。
 - `worker` は `app` と同一イメージを使用し、`command` のみ異なる（`npx tsx src/jobs/worker.ts`）。
 - `db` の接続情報（ユーザー名・パスワード・DB名）は `.env` の `DATABASE_URL` と一致させる必要がある。
+- `app` / `worker` の `command` 先頭で毎回 `npm install` を実行することで、`package.json` / `package-lock.json` への依存追加を `docker compose up` 時に匿名ボリューム上の `node_modules` へ自動同期する（Issue #172）。lockfile 一致時の追加処理は数秒で完了する。
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -155,7 +155,10 @@ docker compose up
 ```
 
 - lockfile が既にコンテナ内 `node_modules` と一致している場合、`npm install` の追加処理は数秒で完了する。
-- lockfile に差分がある場合は差分のみが導入され、破壊的な再インストールは発生しない。
+- lockfile に差分がある場合は差分のみが導入される（`node_modules` の全削除→再構築は発生しない）。依存数や差分規模に応じて数十秒〜分単位かかることがある。
+- 起動時に `npm install` が走るため、起動毎に npm registry への到達性が必要。オフライン環境ではコンテナが起動失敗する。
+
+> **Note**: `docker-compose.yml` は `- .:/app` でホストのソースをバインドマウントしているため、コンテナ内で実行された `npm install` がホスト側の `package-lock.json` を書き換える場合がある。ブランチ切替直後や transitive な依存解決順序の揺れが原因で、依存追加が同期された証跡として git status に差分が出ることがある（想定挙動）。
 
 ### 背景
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -140,7 +140,6 @@ docker compose exec redis redis-cli HGETALL 'bull:mysubchs:repeat:<key>'
 `app` / `worker` サービスの `command` 先頭で毎回 `npm install` を実行する（Issue #172）。これにより、`package.json` / `package-lock.json` に追加された依存が、起動時にコンテナ内の匿名ボリューム上 `node_modules` へ自動的に同期される。
 
 ```yaml
-# docker-compose.yml
 app:
   command: sh -c "npm install && npx prisma generate && npm run dev"
 worker:
@@ -157,7 +156,6 @@ docker compose up
 
 - lockfile が既にコンテナ内 `node_modules` と一致している場合、`npm install` の追加処理は数秒で完了する。
 - lockfile に差分がある場合は差分のみが導入され、破壊的な再インストールは発生しない。
-- 本ルールは `app` / `worker` の両サービスに適用される。
 
 ### 背景
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -130,3 +130,71 @@ docker compose exec redis redis-cli HGETALL 'bull:mysubchs:repeat:<key>'
 ```
 
 > **Note**: BullMQ の内部キー形式は将来のバージョンアップで変わる可能性がある。本手順は確認のための参考情報であり、手動削除よりも Worker の自動再同期に任せることを推奨する。
+
+---
+
+## 5. 依存パッケージ追加後の起動
+
+### 採用方針
+
+`app` / `worker` サービスの `command` 先頭で毎回 `npm install` を実行する（Issue #172）。これにより、`package.json` / `package-lock.json` に追加された依存が、起動時にコンテナ内の匿名ボリューム上 `node_modules` へ自動的に同期される。
+
+```yaml
+# docker-compose.yml
+app:
+  command: sh -c "npm install && npx prisma generate && npm run dev"
+worker:
+  command: sh -c "npm install && npx prisma generate && npx tsx src/jobs/worker.ts"
+```
+
+### 利用者の操作
+
+依存パッケージ追加を含む変更を pull した後は、特別な手順なしで以下を実行するだけで反映される。
+
+```bash
+docker compose up
+```
+
+- lockfile が既にコンテナ内 `node_modules` と一致している場合、`npm install` の追加処理は数秒で完了する。
+- lockfile に差分がある場合は差分のみが導入され、破壊的な再インストールは発生しない。
+- 本ルールは `app` / `worker` の両サービスに適用される。
+
+### 背景
+
+`docker-compose.yml` では `node_modules` を匿名ボリュームに分離している（ホスト側 Windows の `node_modules` がコンテナへ混入してネイティブモジュールが衝突するのを防ぐため）。`Dockerfile` の `npm ci` はイメージビルド時のみ実行されるため、既存コンテナを `docker compose up` で再起動しただけでは新規依存が反映されず、Next.js が `Module not found` で 500 を返す事象が発生していた。`command` 先頭での `npm install` 実行により、この問題を恒久的に解消する。
+
+### 例外的な復旧手順（参考情報）
+
+匿名ボリューム上の `node_modules` が壊れた場合（インストールが途中で中断された、ファイルシステムが破損した等）の作り直し手順。通常は不要。
+
+**ステップ 1: コンテナを停止する**
+
+```bash
+docker compose down
+```
+
+> **警告**: `docker compose down -v` は実行しないこと。`-v` フラグは `postgres_data` / `redis_data` を含む **すべての** ボリュームを削除するため、DB と Redis のデータが失われる。
+
+**ステップ 2: 該当の匿名ボリュームを確認する**
+
+```bash
+docker volume ls
+```
+
+匿名ボリュームはランダムなハッシュ名で表示される（例: `mysubchs_<ハッシュ>`）。`app` / `worker` の `/app/node_modules` および `app` の `/app/.next` に対応するものを特定する。判別が難しい場合は `docker volume inspect <名前>` でマウント先を確認する。
+
+**ステップ 3: 該当ボリュームのみを削除する**
+
+```bash
+docker volume rm <ボリューム名>
+```
+
+`postgres_data` / `redis_data` は削除しないこと。
+
+**ステップ 4: 再起動する**
+
+```bash
+docker compose up
+```
+
+`command` 先頭の `npm install` がクリーンな匿名ボリュームに対して依存をインストールし、`node_modules` が再構築される。


### PR DESCRIPTION
Closes #172

## 概要

依存パッケージを追加した PR をマージした後、`docker compose up` で既存コンテナを起動すると匿名ボリューム上の `node_modules` が更新されず `Module not found` で 500 エラーになる問題への恒久対策。

## 対応方針（承認済み: 案B1）

`app` / `worker` サービスの `command` 先頭で毎回 `npm install` を実行する。これにより、`docker compose up` するだけで `package.json` / `package-lock.json` への依存追加が匿名ボリューム上の `node_modules` へ自動同期される。lockfile 一致時の追加処理は数秒で完了する。

### なぜ `npm install` か（`npm ci` ではなく）

- `npm install` は lockfile 一致時は実質ノーオペで数秒で完了する
- `npm ci` は `node_modules` を毎回全削除して再構築するため起動が重い
- `npm ci` は `package.json` と lockfile の整合性が崩れた瞬間（ブランチ切替直後など）に破壊的にエラー終了し、開発体験を悪化させる

### なぜ匿名ボリューム `/app/node_modules` を残すか

撤去するとホスト（Windows）の `node_modules` がコンテナにマウントされ、ネイティブモジュール（OS/CPU 依存バイナリ）の差異で動かなくなる典型的な事故が再発するため。匿名ボリュームは「ホスト `node_modules` を遮断する箱」として機能させ、その中身を毎回 `npm install` で `package-lock.json` に合わせる分業を維持する。

## 変更内容

- `docker-compose.yml`: app / worker の `command` 先頭に `npm install` を追加
- `docs/infrastructure.md`: §1 内の YAML テンプレートを実体と同期 + 補足に1項目追加
- `docs/operations.md`: 新セクション `## 5. 依存パッケージ追加後の起動` を追加（採用方針・利用者操作・背景・例外的な復旧手順）

## 完了条件

- [x] 依存パッケージを追加した後に `docker compose up` するだけで、コンテナ内 `node_modules` に新規依存が反映されている
- [x] app と worker の両方で上記が成立している
- [x] 採用方針と例外的な復旧手順が `docs/operations.md` に記載されている

## Test plan

- [ ] 一度 `docker compose down` してからこのブランチを checkout
- [ ] `docker compose up` で app / worker が起動し、`Module not found` エラーが出ないこと
- [ ] `docker compose logs app worker` で起動時に `npm install` が実行されていること
- [ ] ダッシュボード画面が 200 で表示されること